### PR TITLE
[FEAT]사용자 정보 수정, 삭제 구현

### DIFF
--- a/src/main/java/com/example/petlog/controller/UserController.java
+++ b/src/main/java/com/example/petlog/controller/UserController.java
@@ -20,6 +20,23 @@ public class UserController {
         return ResponseEntity.ok(userService.createUser(request));
     }
 
+    @PostMapping("/me")
+    public ResponseEntity<UserResponse.UpdateUserDto> updateUser(@RequestHeader("X-USER-ID") Long userId, @Valid @RequestBody UserRequest.UpdateUserDto request) {
+        return ResponseEntity.ok(userService.updateUser(userId, request));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<String> deleteUser(@RequestHeader("X-USER-ID") Long userId) {
+        userService.deleteUser(userId);
+        return ResponseEntity.ok("해당 회원 정보가 삭제되었습니다.");
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteUserByUserId(@PathVariable("id") Long userId) {
+        userService.deleteUser(userId);
+        return ResponseEntity.ok("해당 회원 정보가 삭제되었습니다.");
+    }
+
     @PostMapping("/login")
     public ResponseEntity<UserResponse.LoginDto> login(
             @RequestBody UserRequest.LoginDto loginRequestDto

--- a/src/main/java/com/example/petlog/dto/request/UserRequest.java
+++ b/src/main/java/com/example/petlog/dto/request/UserRequest.java
@@ -43,4 +43,21 @@ public class UserRequest{
         private String password;
 
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class UpdateUserDto {
+
+        @NotNull
+        private String username;
+        @NotNull
+        private Integer age;
+        @NotNull
+        private String profileImage;
+
+        @NotNull
+        private GenderType genderType;
+
+    }
 }

--- a/src/main/java/com/example/petlog/dto/response/UserResponse.java
+++ b/src/main/java/com/example/petlog/dto/response/UserResponse.java
@@ -128,6 +128,29 @@ public class UserResponse {
         }
     }
 
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateUserDto {
+        //사용자 이름(닉네임)
+        private String username;
+        //성별
+        private GenderType genderType;
+        //프로필 사진
+        private String profileImage;
+        //나이
+        private Integer age;
 
+        public static UpdateUserDto fromEntity(User user) {
+
+            return UpdateUserDto.builder()
+                    .username(user.getUsername())
+                    .genderType(user.getGenderType())
+                    .profileImage(user.getProfileImage())
+                    .age(user.getAge())
+                    .build();
+        }
+    }
 
 }

--- a/src/main/java/com/example/petlog/entity/User.java
+++ b/src/main/java/com/example/petlog/entity/User.java
@@ -80,6 +80,12 @@ public class User {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-
+    public void updateUser(String username, int age, String profileImage, GenderType genderType) {
+        // 필요하다면 이 곳에서 유효성 검증 로직을 추가할 수 있습니다.
+        this.username = username;
+        this.age = age;
+        this.profileImage = profileImage;
+        this.genderType = genderType;
+    }
 
 }

--- a/src/main/java/com/example/petlog/service/UserService.java
+++ b/src/main/java/com/example/petlog/service/UserService.java
@@ -2,6 +2,7 @@ package com.example.petlog.service;
 
 import com.example.petlog.dto.request.UserRequest;
 import com.example.petlog.dto.response.UserResponse;
+import jakarta.validation.Valid;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 public interface UserService {
@@ -11,4 +12,8 @@ public interface UserService {
     UserResponse.AuthDto getUserDetailsByUserId(String userId);
 
     UserResponse.GetUserDto getUser(Long userId);
+
+    UserResponse.UpdateUserDto updateUser(Long userId, UserRequest.UpdateUserDto request);
+
+    void deleteUser(Long userId);
 }

--- a/src/main/java/com/example/petlog/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/petlog/service/impl/UserServiceImpl.java
@@ -139,4 +139,27 @@ public class UserServiceImpl implements UserService {
         return UserResponse.GetUserDto.fromEntity(user,petList);
     }
 
+    @Override
+    public UserResponse.UpdateUserDto updateUser(Long userId, UserRequest.UpdateUserDto request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        user.updateUser(
+                request.getUsername(),
+                request.getAge(),
+                request.getProfileImage(),
+                request.getGenderType()
+        );
+        userRepository.save(user);
+        return UserResponse.UpdateUserDto.fromEntity(user);
+
+    }
+
+    @Override
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        userRepository.delete(user);
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈
#9

## 작업 내용
- 닉네임, 나이, 프로필, 성별을 수정하는 api 구현
-  로그인한 사용자의 정보를 삭제하는 api 구현(회원 탈퇴)
- 특정 사용자의 id값을 받아 해당 사용자의 정보를 삭제하는 api 구현

## 테스트 결과
- [ ] Swagger 테스트 완료


## 📸 스크린샷 (선택)
<img width="477" height="242" alt="image" src="https://github.com/user-attachments/assets/80a7d561-7b0f-414c-a4c8-252a9424f406" />
<img width="428" height="158" alt="image" src="https://github.com/user-attachments/assets/ab025230-566b-4e57-82c5-3a95215b8e42" />

