### PR TITLE
[FEAT] 펫코인 조회, 적립, 차감  

### DIFF
--- a/src/main/java/com/example/petlog/controller/UserController.java
+++ b/src/main/java/com/example/petlog/controller/UserController.java
@@ -54,4 +54,19 @@ public class UserController {
     public ResponseEntity<UserResponse.UpdateProfileDto> updateProfile(@RequestHeader("X-USER-ID") Long userId, @Valid @RequestBody UserRequest.UpdateProfileDto request) {
         return ResponseEntity.ok(userService.updateProfile(userId, request));
     }
+    @GetMapping("/{id}/coin")
+    public ResponseEntity<UserResponse.CoinDto> getCoin(@PathVariable("id") Long userId) {
+        return ResponseEntity.ok(userService.getCoin(userId));
+    }
+
+
+    @PostMapping("/{id}/coin/earn")
+    public ResponseEntity<UserResponse.CoinDto> earnCoin(@PathVariable("id") Long userId, @Valid @RequestBody UserRequest.CoinDto request) {
+        return ResponseEntity.ok(userService.earnCoin(userId, request));
+    }
+
+    @PostMapping("/{id}/coin/redeem")
+    public ResponseEntity<UserResponse.CoinDto> redeemCoin(@PathVariable("id") Long userId, @Valid @RequestBody UserRequest.CoinDto request) {
+        return ResponseEntity.ok(userService.redeemCoin(userId, request));
+    }
 }

--- a/src/main/java/com/example/petlog/dto/request/UserRequest.java
+++ b/src/main/java/com/example/petlog/dto/request/UserRequest.java
@@ -76,4 +76,12 @@ public class UserRequest{
         private String username;
 
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class CoinDto {
+        @NotNull
+        private Long amount;
+    }
 }

--- a/src/main/java/com/example/petlog/dto/response/UserResponse.java
+++ b/src/main/java/com/example/petlog/dto/response/UserResponse.java
@@ -170,12 +170,28 @@ public class UserResponse {
 
         public static UpdateProfileDto fromEntity(User user) {
 
-            return UpdateProfileDto .builder()
+            return UpdateProfileDto.builder()
                     .username(user.getUsername())
                     .profileImage(user.getProfileImage())
                     .statusMessage(user.getStatusMessage())
                     .build();
         }
     }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CoinDto {
+        private Long petCoin;
+
+        public static CoinDto fromEntity(User user) {
+            return CoinDto.builder()
+                    .petCoin(user.getPetCoin())
+                    .build();
+        }
+
+    }
+
 
 }

--- a/src/main/java/com/example/petlog/entity/User.java
+++ b/src/main/java/com/example/petlog/entity/User.java
@@ -1,5 +1,7 @@
 package com.example.petlog.entity;
 
+import com.example.petlog.exception.BusinessException;
+import com.example.petlog.exception.ErrorCode;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
@@ -92,9 +94,19 @@ public class User {
         this.genderType = genderType;
     }
 
-    public void updateProfile(@NotNull String username, @NotNull String profileImage, @NotNull String statusMessage) {
+    public void updateProfile(String username,String profileImage,String statusMessage) {
         this.username = username;
         this.profileImage = profileImage;
         this.statusMessage = statusMessage;
+    }
+
+    public void earnCoin(Long amount) {
+        this.petCoin += amount;
+    }
+    public void redeemCoin(Long petCoin, Long amount) {
+        if (petCoin < amount) {
+            throw new BusinessException(ErrorCode.PET_COIN_NOT_ENOUGH);
+        }
+        this.petCoin -= amount;
     }
 }

--- a/src/main/java/com/example/petlog/exception/ErrorCode.java
+++ b/src/main/java/com/example/petlog/exception/ErrorCode.java
@@ -27,7 +27,7 @@ public enum ErrorCode {
     //펫 관련
     PET_NAME_DUPLICATE("PET_002","중복된 이름입니다.", HttpStatus.BAD_REQUEST),
     PET_NOT_FOUND("PET_002","펫을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-
+    PET_COIN_NOT_ENOUGH("PET_003","펫코인이 부족합니다.", HttpStatus.BAD_REQUEST),
 
     // 서버 오류 (50X)
     INTERNAL_SERVER_ERROR("SERVER_001", "서버 내부 오류가 발생했습니다", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/example/petlog/service/UserService.java
+++ b/src/main/java/com/example/petlog/service/UserService.java
@@ -18,4 +18,10 @@ public interface UserService {
     void deleteUser(Long userId);
 
     UserResponse.UpdateProfileDto updateProfile(Long userId, UserRequest.@Valid UpdateProfileDto request);
+
+    UserResponse.CoinDto getCoin(Long userId);
+
+    UserResponse.CoinDto earnCoin(Long userId, UserRequest.@Valid CoinDto request);
+
+    UserResponse.CoinDto redeemCoin(Long userId, UserRequest.@Valid CoinDto request);
 }

--- a/src/main/java/com/example/petlog/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/petlog/service/impl/UserServiceImpl.java
@@ -176,4 +176,30 @@ public class UserServiceImpl implements UserService {
         return UserResponse.UpdateProfileDto.fromEntity(user);
     }
 
+    @Override
+    public UserResponse.CoinDto getCoin(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return UserResponse.CoinDto.fromEntity(user);
+    }
+
+    @Override
+    public UserResponse.CoinDto earnCoin(Long userId, UserRequest.@Valid CoinDto request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        user.earnCoin(request.getAmount());
+        userRepository.save(user);
+        return UserResponse.CoinDto.fromEntity(user);
+
+    }
+
+    @Override
+    public UserResponse.CoinDto redeemCoin(Long userId, UserRequest.@Valid CoinDto request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        user.redeemCoin(user.getPetCoin(), request.getAmount());
+        userRepository.save(user);
+        return UserResponse.CoinDto.fromEntity(user);
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈
- #15

## 작업 내용
- 펫코인 조회: 사용자의 id값을 받아 펫코인을 조회합니다.
- 펫코인 적립: 사용자의 id값과 적립할 금액을 받아 펫코인을 적립합니다.
- 펫코인 차감: 사용자의 id값과 차감할 금액을 받아 받아 펫코인을 차감합니다. 현재 펫코인 잔액보다 차감하려는 금액이 더 큰 경우 예외를 발생시킵니다.  

## 테스트 결과
- [x] Swagger 테스트 완료

## 📸 스크린샷 (선택)
펫코인 조회
<img width="466" height="469" alt="image" src="https://github.com/user-attachments/assets/ea97a667-1a6e-4f8c-9acb-5cb886fa8794" />
펫코인 적립
<img width="255" height="182" alt="image" src="https://github.com/user-attachments/assets/e62881a4-2cb9-45ac-a14e-30bd02a86c17" />

<img width="438" height="538" alt="image" src="https://github.com/user-attachments/assets/67525f50-92d4-4622-be86-b1103f70be7d" />

펫코인 차감
<img width="255" height="285" alt="image" src="https://github.com/user-attachments/assets/114cad9d-411d-4834-a7fb-d8a4b95a91e6" />
<img width="447" height="511" alt="image" src="https://github.com/user-attachments/assets/88d547fd-dc92-4161-84b8-056c63d49117" />

<img width="551" height="465" alt="image" src="https://github.com/user-attachments/assets/68cfc428-d018-4278-9867-8e9d1e63aae4" />

