### PR TITLE
[FEAT] 소셜 아이디로 사용자를 검색하기

### DIFF
--- a/src/main/java/com/example/petlog/controller/UserController.java
+++ b/src/main/java/com/example/petlog/controller/UserController.java
@@ -86,4 +86,10 @@ public class UserController {
     public ResponseEntity<UserResponse.CoinDto> redeemCoin(@PathVariable("id") Long userId, @Valid @RequestBody UserRequest.CoinDto request) {
         return ResponseEntity.ok(userService.redeemCoin(userId, request));
     }
+
+    @Operation(summary = "사용자 검색", description = "소셜 아이디로 사용자를 검색합니다.")
+    @GetMapping("/search")
+    public ResponseEntity<UserResponse.GetSearchedUserDtoList> searchUsersWithSocial(@RequestParam("keyword") String keyword) {
+        return ResponseEntity.ok(userService.searchUsersWithSocial(keyword));
+    }
 }

--- a/src/main/java/com/example/petlog/dto/response/UserResponse.java
+++ b/src/main/java/com/example/petlog/dto/response/UserResponse.java
@@ -205,5 +205,61 @@ public class UserResponse {
 
     }
 
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class GetSearchedUserDto {
+        //사용자 id
+        Long userId;
+        //사용자 이름(닉네임)
+        private String username;
+        //성별
+        private GenderType genderType;
+        //프로필 사진
+        private String profileImage;
+        //소설
+        private String social;
+        //상태메세지
+        private String statusMessage;
+        //나이
+        private Integer age;
+
+        public static GetSearchedUserDto fromEntity(User user) {
+
+            return GetSearchedUserDto.builder()
+                    .userId(user.getId())
+                    .statusMessage(user.getStatusMessage())
+                    .username(user.getUsername())
+                    .social(user.getSocial())
+                    .genderType(user.getGenderType())
+                    .profileImage(user.getProfileImage())
+                    .age(user.getAge())
+                    .build();
+        }
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class GetSearchedUserDtoList {
+
+        //사용자 이름(닉네임)
+        boolean isNull;
+        private List<GetSearchedUserDto> users;
+
+        public static GetSearchedUserDtoList fromEntity(List<User> users) {
+            boolean isEmpty = users.isEmpty();
+            List<GetSearchedUserDto> getSearchedUserDtoList = users.stream()
+                    .map(user -> GetSearchedUserDto.fromEntity(user))
+                    .toList();
+            return GetSearchedUserDtoList.builder()
+                    .users(getSearchedUserDtoList)
+                    .isNull(isEmpty)
+                    .build();
+        }
+    }
+
 
 }

--- a/src/main/java/com/example/petlog/repository/UserRepository.java
+++ b/src/main/java/com/example/petlog/repository/UserRepository.java
@@ -4,6 +4,7 @@ import com.example.petlog.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,4 +18,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     boolean existsByUsername(String username);
     Optional<User> findByUsername(String username);
+    List<User> findBySocialContaining(String keyword);
 }

--- a/src/main/java/com/example/petlog/service/UserService.java
+++ b/src/main/java/com/example/petlog/service/UserService.java
@@ -27,4 +27,6 @@ public interface UserService {
     UserResponse.CoinDto earnCoin(Long userId, UserRequest.@Valid CoinDto request);
 
     UserResponse.CoinDto redeemCoin(Long userId, UserRequest.@Valid CoinDto request);
+
+    UserResponse.GetSearchedUserDtoList searchUsersWithSocial(String keyword);
 }

--- a/src/main/java/com/example/petlog/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/petlog/service/impl/UserServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.core.env.Environment;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.crypto.SecretKey;
@@ -51,7 +52,7 @@ public class UserServiceImpl implements UserService {
     private final Utils utils;
     private final Environment env;
 
-
+    @Transactional
     @Override
     // 유저 생성
     public UserResponse.CreateUserDto createUser(List<MultipartFile> multipartFiles, UserRequest.CreateUserAndPetDto request) {
@@ -145,7 +146,7 @@ public class UserServiceImpl implements UserService {
                 .signWith(secretKey)
                 .compact();
     }
-
+    @Transactional(readOnly = true)
     @Override
     // 유저 정보, 반려견 정보 반환
     public UserResponse.GetUserDto getUser(Long userId) {
@@ -158,7 +159,7 @@ public class UserServiceImpl implements UserService {
 
         return UserResponse.GetUserDto.fromEntity(user,petList);
     }
-
+    @Transactional
     @Override
     public UserResponse.UpdateUserDto updateUser(Long userId, UserRequest.UpdateUserDto request) {
         User user = userRepository.findById(userId)
@@ -174,14 +175,14 @@ public class UserServiceImpl implements UserService {
         return UserResponse.UpdateUserDto.fromEntity(user);
 
     }
-
+    @Transactional
     @Override
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         userRepository.delete(user);
     }
-
+    @Transactional
     @Override
     public UserResponse.UpdateProfileDto updateProfile(Long userId, UserRequest.@Valid UpdateProfileDto request) {
         User user = userRepository.findById(userId)
@@ -194,14 +195,14 @@ public class UserServiceImpl implements UserService {
         userRepository.save(user);
         return UserResponse.UpdateProfileDto.fromEntity(user);
     }
-
+    @Transactional
     @Override
     public UserResponse.CoinDto getCoin(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         return UserResponse.CoinDto.fromEntity(user);
     }
-
+    @Transactional
     @Override
     public UserResponse.CoinDto earnCoin(Long userId, UserRequest.@Valid CoinDto request) {
         User user = userRepository.findById(userId)
@@ -211,7 +212,7 @@ public class UserServiceImpl implements UserService {
         return UserResponse.CoinDto.fromEntity(user);
 
     }
-
+    @Transactional
     @Override
     public UserResponse.CoinDto redeemCoin(Long userId, UserRequest.@Valid CoinDto request) {
         User user = userRepository.findById(userId)
@@ -221,6 +222,13 @@ public class UserServiceImpl implements UserService {
         return UserResponse.CoinDto.fromEntity(user);
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public UserResponse.GetSearchedUserDtoList searchUsersWithSocial(String keyword) {
+        List<User> users = userRepository.findBySocialContaining(keyword);
+        return UserResponse.GetSearchedUserDtoList.fromEntity(users);
+
+    }
 
 
 }


### PR DESCRIPTION
## 관련 이슈
- #24

## 작업 내용
-검색 키워드를 쿼리 스트링으로 받아서 소셜 아이디에 키워드가 포함된 모든 사용자를 조회합니다. 검색된 사용자가 없을 시 Empty값을 true로 반환합니다.  
## 테스트 결과
- [x] Swagger 테스트 완료

## 📸 스크린샷 (선택)
<img width="527" height="793" alt="image" src="https://github.com/user-attachments/assets/58eecde3-2c58-46cc-938d-537faf3e74dc" />
<img width="418" height="372" alt="image" src="https://github.com/user-attachments/assets/3bf0f9cc-bc79-48b7-acae-81511712ea30" />
<img width="171" height="44" alt="image" src="https://github.com/user-attachments/assets/640facee-559e-4a6b-a8a7-1d181e924844" />
