### PR TITLE
[Refactor] 펫 등록, 프로필 페이지 조회, 펫 상세조회, 사용자 프로필 수정, 펫 프로필 수정 프론트와 연동 

### DIFF
--- a/src/main/java/com/example/petlog/controller/PetController.java
+++ b/src/main/java/com/example/petlog/controller/PetController.java
@@ -21,14 +21,14 @@ public class PetController {
 
     @Operation(summary = "펫 등록", description = "새로운 펫을 등록합니다.")
     @PostMapping(value = "/create" ,consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<PetResponse.CreatePetDto> createPet(@RequestPart(value = "multipartFile",required = false) MultipartFile multipartFile, @RequestHeader("X-USER-ID") Long userId, @Valid @RequestPart PetRequest.CreatePetDto request) {
+    public ResponseEntity<PetResponse.CreatePetDto> createPet(@RequestPart(value = "multipartFile",required = false) MultipartFile multipartFile, @RequestHeader("X-USER-ID") Long userId, @Valid @RequestPart("request") PetRequest.CreatePetDto request) {
         return ResponseEntity.ok(petService.createPet(multipartFile, userId, request));
     }
 
     @Operation(summary = "펫 정보 수정", description = "기존 펫의 정보를 수정합니다.")
-    @PatchMapping("/{petId}")
-    public ResponseEntity<PetResponse.UpdatePetDto> updatePet(@PathVariable Long petId, @Valid @RequestBody PetRequest.UpdatePetDto request) {
-        return ResponseEntity.ok(petService.updatePet(petId, request));
+    @PatchMapping(value = "/{petId}",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<PetResponse.UpdatePetDto> updatePet(@RequestHeader("X-USER-ID") Long userId, @PathVariable Long petId,@RequestPart(value = "multipartFile",required = false) MultipartFile multipartFile, @Valid @RequestPart PetRequest.UpdatePetDto request) {
+        return ResponseEntity.ok(petService.updatePet(userId, multipartFile, petId, request));
     }
 
     @Operation(summary = "펫 정보 조회", description = "특정 ID의 펫 정보를 조회합니다.")

--- a/src/main/java/com/example/petlog/controller/UserController.java
+++ b/src/main/java/com/example/petlog/controller/UserController.java
@@ -64,9 +64,9 @@ public class UserController {
     }
 
     @Operation(summary = "프로필 수정", description = "현재 로그인된 사용자의 프로필 정보를 수정합니다.")
-    @PatchMapping("/me")
-    public ResponseEntity<UserResponse.UpdateProfileDto> updateProfile(@RequestHeader("X-USER-ID") Long userId, @Valid @RequestBody UserRequest.UpdateProfileDto request) {
-        return ResponseEntity.ok(userService.updateProfile(userId, request));
+    @PatchMapping(value= "/me",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UserResponse.UpdateProfileDto> updateProfile(@RequestHeader("X-USER-ID") Long userId, @RequestPart(value = "userProfile", required = false) MultipartFile userProfile, @Valid @RequestPart("request") UserRequest.UpdateProfileDto request) {
+        return ResponseEntity.ok(userService.updateProfile(userId, userProfile, request));
     }
 
     @Operation(summary = "코인 수량 조회", description = "특정 ID의 사용자 코인 수량을 조회합니다.")

--- a/src/main/java/com/example/petlog/dto/request/PetRequest.java
+++ b/src/main/java/com/example/petlog/dto/request/PetRequest.java
@@ -1,8 +1,7 @@
 package com.example.petlog.dto.request;
 
 
-import com.example.petlog.entity.GenderType;
-import com.example.petlog.entity.Species;
+import com.example.petlog.entity.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,7 +36,25 @@ public class PetRequest {
         //중성화여부
         @NotNull
         private boolean neutered;
+        //예방접종 여부
+        @NotNull
+        private boolean vaccinated;
 
+        public static Pet toEntity(User user, CreatePetDto request, Integer age, String profileImage) {
+            return Pet.builder()
+                    .user(user)
+                    .petName(request.getPetName())
+                    .genderType(request.getGenderType())
+                    .breed(request.getBreed())
+                    .age(age)
+                    .status(Status.ALIVE)
+                    .birth(request.getBirth())
+                    .species(request.getSpecies())
+                    .neutered(request.isNeutered())
+                    .profileImage(profileImage)
+                    .isVaccinated(request.isVaccinated())
+                    .build();
+        }
     }
 
     @Getter
@@ -59,8 +76,7 @@ public class PetRequest {
         private Species species;
         //중성화여부
         private boolean neutered;
-        //프로필 사진
-        private String profileImage;
-
+        //예방접종 여부
+        private boolean vaccinated;
     }
 }

--- a/src/main/java/com/example/petlog/dto/request/UserRequest.java
+++ b/src/main/java/com/example/petlog/dto/request/UserRequest.java
@@ -82,13 +82,9 @@ public class UserRequest{
     public static class UpdateProfileDto {
 
         @NotNull
-        private String statusMessage;
-
-        @NotNull
-        private String profileImage;
-
-        @NotNull
         private String username;
+        @NotNull
+        private String social;
 
     }
 

--- a/src/main/java/com/example/petlog/dto/response/PetResponse.java
+++ b/src/main/java/com/example/petlog/dto/response/PetResponse.java
@@ -38,6 +38,8 @@ public class PetResponse {
         private LocalDate birth;
         //상태
         private Status status;
+        //예방접종
+        private boolean vaccinated;
         //생성일
         private LocalDateTime createdAt;
 
@@ -55,6 +57,7 @@ public class PetResponse {
                     .neutered(pet.isNeutered())
                     .birth(pet.getBirth())
                     .status(pet.getStatus())
+                    .vaccinated(pet.isVaccinated())
                     .createdAt(pet.getCreatedAt())
                     .build();
         }
@@ -76,7 +79,7 @@ public class PetResponse {
         //성별
         private GenderType genderType;
         //중성화여부
-        private boolean is_neutered;
+        private boolean neutered;
         //프로필 사진
         private String profileImage;
         //나이
@@ -85,6 +88,8 @@ public class PetResponse {
         private LocalDate birth;
         //상태
         private Status status;
+        //예방접종
+        private boolean vaccinated;
 
 
         public static PetResponse.GetPetDto fromEntity(Pet pet) {
@@ -95,11 +100,12 @@ public class PetResponse {
                     .species(pet.getSpecies())
                     .breed(pet.getBreed())
                     .genderType(pet.getGenderType())
-                    .is_neutered(pet.isNeutered())
+                    .neutered(pet.isNeutered())
                     .profileImage(pet.getProfileImage())
                     .age(pet.getAge())
                     .birth(pet.getBirth())
                     .status(pet.getStatus())
+                    .vaccinated(pet.isVaccinated())
                     .build();
         }
 
@@ -129,7 +135,8 @@ public class PetResponse {
         private LocalDate birth;
         //상태
         private Status status;
-
+        //예방접종
+        private boolean vaccinated;
 
         public static PetResponse.UpdatePetDto fromEntity(Pet pet) {
 
@@ -144,6 +151,7 @@ public class PetResponse {
                     .age(pet.getAge())
                     .birth(pet.getBirth())
                     .status(pet.getStatus())
+                    .vaccinated(pet.isVaccinated())
                     .build();
         }
 

--- a/src/main/java/com/example/petlog/dto/response/UserResponse.java
+++ b/src/main/java/com/example/petlog/dto/response/UserResponse.java
@@ -177,15 +177,15 @@ public class UserResponse {
         private String username;
         //프로필 사진
         private String profileImage;
-        //상태메세지
-        private String statusMessage;
+        //소설아이디
+        private String social;
 
         public static UpdateProfileDto fromEntity(User user) {
 
             return UpdateProfileDto.builder()
                     .username(user.getUsername())
                     .profileImage(user.getProfileImage())
-                    .statusMessage(user.getStatusMessage())
+                    .social(user.getSocial())
                     .build();
         }
     }

--- a/src/main/java/com/example/petlog/entity/Pet.java
+++ b/src/main/java/com/example/petlog/entity/Pet.java
@@ -64,6 +64,10 @@ public class Pet {
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    //예방접종 여부
+    @Column(nullable = false)
+    private boolean isVaccinated;
+
     @CreationTimestamp
     @Column(updatable = false)
     private LocalDateTime createdAt;
@@ -71,7 +75,7 @@ public class Pet {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-    public void updatePet(String petName, String breed, GenderType genderType, Integer age, LocalDate birth, Species species, boolean neutered, String profileImage) {
+    public void updatePet(String petName, String breed, GenderType genderType, Integer age, LocalDate birth, Species species, boolean neutered, String profileImage, boolean vaccinated) {
         this.petName = petName;
         this.breed = breed;
         this.genderType = genderType;
@@ -80,7 +84,7 @@ public class Pet {
         this.species = species;
         this.neutered = neutered;
         this.profileImage = profileImage;
-
+        this.isVaccinated = vaccinated;
     }
 
     public void lostPet() {

--- a/src/main/java/com/example/petlog/entity/User.java
+++ b/src/main/java/com/example/petlog/entity/User.java
@@ -105,10 +105,10 @@ public class User {
         this.genderType = genderType;
     }
 
-    public void updateProfile(String username,String profileImage,String statusMessage) {
+    public void updateProfile(String username,String profileImage,String social) {
         this.username = username;
         this.profileImage = profileImage;
-        this.statusMessage = statusMessage;
+        this.social = social;
     }
 
     public void earnCoin(Long amount) {

--- a/src/main/java/com/example/petlog/service/PetService.java
+++ b/src/main/java/com/example/petlog/service/PetService.java
@@ -9,7 +9,7 @@ public interface PetService {
 
     PetResponse.CreatePetDto createPet(MultipartFile multipartFile, Long userNum, PetRequest.CreatePetDto request);
 
-    PetResponse.UpdatePetDto updatePet(Long petId, PetRequest.UpdatePetDto request);
+    PetResponse.UpdatePetDto updatePet(Long userId, MultipartFile multipartFile, Long petId, PetRequest.UpdatePetDto request);
 
     PetResponse.GetPetDto getPet(Long petId);
 

--- a/src/main/java/com/example/petlog/service/UserService.java
+++ b/src/main/java/com/example/petlog/service/UserService.java
@@ -20,7 +20,7 @@ public interface UserService {
 
     void deleteUser(Long userId);
 
-    UserResponse.UpdateProfileDto updateProfile(Long userId, UserRequest.@Valid UpdateProfileDto request);
+    UserResponse.UpdateProfileDto updateProfile(Long userId, MultipartFile userProfile, UserRequest.UpdateProfileDto request);
 
     UserResponse.CoinDto getCoin(Long userId);
 

--- a/src/main/java/com/example/petlog/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/petlog/service/impl/UserServiceImpl.java
@@ -187,13 +187,21 @@ public class UserServiceImpl implements UserService {
     }
     @Transactional
     @Override
-    public UserResponse.UpdateProfileDto updateProfile(Long userId, UserRequest.@Valid UpdateProfileDto request) {
+    public UserResponse.UpdateProfileDto updateProfile(Long userId,MultipartFile userProfile, UserRequest.UpdateProfileDto request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        String profileImage = user.getProfileImage();
+        if (userProfile != null && !userProfile.isEmpty()) {
+            List<MultipartFile> userProfiles = List.of(userProfile);
+            List<String> urls = imageService.upload(userProfiles);
+            profileImage = urls.get(0);
+        }
+
         user.updateProfile(
                 request.getUsername(),
-                request.getProfileImage(),
-                request.getStatusMessage()
+                profileImage,
+                request.getSocial()
         );
         userRepository.save(user);
         return UserResponse.UpdateProfileDto.fromEntity(user);


### PR DESCRIPTION
## 관련 이슈
- #23

## 작업 내용
-사용자 프로필 페이지 조회, 펫 상세조회, 사용자 프로필 수정, 펫 프로필 수정 api를 프론트에 맞게 수정 
## 테스트 결과
- [x] Front 화면에서 테스트 완료 

## 📸 스크린샷 (선택)
<img width="693" height="545" alt="image" src="https://github.com/user-attachments/assets/8b6a0e83-a23f-4f45-9f23-8f3dfba15924" />
<img width="623" height="549" alt="image" src="https://github.com/user-attachments/assets/f499638f-4b52-4b8d-a366-d4b77c4031e9" />
<img width="562" height="844" alt="image" src="https://github.com/user-attachments/assets/302fc96b-8cac-438a-bc18-1ad0caad1c2a" />
<img width="824" height="731" alt="image" src="https://github.com/user-attachments/assets/5ee0598b-7fa0-43b5-bb6a-5e08e487aec6" />
<img width="548" height="804" alt="image" src="https://github.com/user-attachments/assets/4f0f0af4-584b-4faa-b185-598c86b4fd3b" />

